### PR TITLE
Fix missing build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "files": ["bin/", "src/", "pkg/", "README.md", "LICENSE"],
   "scripts": {
+    "build": "tsc -p tsconfig.json",
     "test": "bun test",
     "typecheck": "tsc -p tsconfig.json",
     "lint": "biome lint",


### PR DESCRIPTION
The release workflow was failing because it calls `bun run build` but no build script existed in package.json.
## Changes
- Added `"build": "tsc -p tsconfig.json"` to package.json scripts
This runs TypeScript type checking during the build step, which is appropriate since this Bun project doesn't require compilation (`noEmit: true`).]